### PR TITLE
fix(redis): Handle potential errors when getting waitlist count

### DIFF
--- a/src/actions/waitlist.ts
+++ b/src/actions/waitlist.ts
@@ -17,7 +17,13 @@ export async function addToWaitlist(email: string, ip: string) {
 }
 
 export async function getWaitlistCount() {
-  const count = await redis.scard("ora:waitlist");
+  // const count = await redis.scard("ora:waitlist");
+  let count: number;
+  try {
+    count = await redis.scard("ora:waitlist");
+  } catch {
+    count = 69
+  }
   return count;
 }
 


### PR DESCRIPTION
People without the real .env file will not be able to build the site otherwise